### PR TITLE
Refactor check_url; use context manager

### DIFF
--- a/checks.py
+++ b/checks.py
@@ -34,24 +34,20 @@ def check_mongo(mongo_uri):
 # ----------------------------------------------------------------------
 # URL
 # ----------------------------------------------------------------------
-def check_url(url, text=None):
-    response = urllib.request.urlopen(url)
-    if response.code >= 200 or response <= 299:
-        print("Connected to URL ", url)
-        if text:
-            for line in response.readlines():
-                if text in line.decode("utf-8"):
-                    print(line)
-                    response.close()
-                    print(f"Text '{text}' found in response.")
-                    return True
-            response.close()
-            print(f"Text '{text}' not found in response.")
+def check_url(url: str, text: str = None) -> bool:
+    print(f"Verifying connectivity to URL: {url}")
+    with urllib.request.urlopen(url) as res:
+        print(f"  Response code: {res.code}")
+        if not (200 <= res.code < 300):
             return False
-        else:
-            response.close()
+        print("  Connected successfully.")
+        if not text:
             return True
-    response.close()
+        print(f"  Searching in response for sentinel text: {text}")
+        for line_no, line in enumerate(res.readlines(), start=1):
+            if text in line.decode():
+                print(f"    Sentinel text found on response line {line_no}:\n  {line}")
+                return True
     return False
 
 


### PR DESCRIPTION
# Problem

When checking a URL, there is only feedback if a successful connection is made.  But what happens if the URL is typoed?  No logs to indicate that _anything_ is happening:

```sh
$ kubectl logs <pod-name> -c <ncsa-checks-pod-name>
[NO OUTPUT HERE]
$
```

# Approach

Much more helpful to log the _un_ happy path (if not all paths) so that when checking to see "what's taking so long?!" there is indication of exactly what is happening, perhaps in real time:

```sh
$ kubectl logs -f <pod-name> -c <ncsa-checks-pod-name>
Verifying connectivity to URL: http://some.fqdn:12345/typoed/path
  Response code: 404
Verifying connectivity to URL: http://some.fqdn:12345/typoed/path
  Response code: 404
...
```
"Ahh ... 404?  Oh, typoed the path."

While, here, refactor to use `with` syntax -- no sense in repeating ourselves (`.close()`).  