### PR TITLE
Build native image for ARM architectures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3.8-slim
 
+# We are going to build the postgres psycopg2 library from source
+# so we need postgres binaries and gcc
+RUN apt-get update && apt-get install -y libpq-dev build-essential
+
 ENV TRIES=0 \
     RABBITMQ_URI="" \
     MONGO_URI="" \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pika>=1.2.0, <2
-psycopg2-binary>=2.9.1, <3
+psycopg2>=2.9.3, <3
 pymongo>=3.12.0, <4


### PR DESCRIPTION
# Problem
The pre-built Postgres library, psycopg2-binary is convenient, but doesn't support Apple Silicon. 

# Approach
1. Updated requirements.txt to build from source
2. Added gcc and Postgres libraries to image to allow pip install to build from source code
