### PR TITLE
Bump version to psycopg2-binary to >= 2.9.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pika>=1.2.0, <2
-psycopg2-binary>=2.9.1, <3
+psycopg2-binary>=2.9.10, <3
 pymongo>=3.12.0, <4


### PR DESCRIPTION
The older version was picking up a deprecated version of libpq This library was causing an error:
   "OperationalError SCRAM authentication requires libpq version 10 or above"